### PR TITLE
Add AVSpeechSynthesisDelegate

### DIFF
--- a/Example/OSSSpeechKit.xcodeproj/project.pbxproj
+++ b/Example/OSSSpeechKit.xcodeproj/project.pbxproj
@@ -228,11 +228,13 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = YY5Y5N88U4;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = YY5Y5N88U4;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 607FACCF1AFB9204008FA782;
@@ -519,7 +521,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YY5Y5N88U4;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = OSSSpeechKit/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -540,7 +542,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YY5Y5N88U4;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = OSSSpeechKit/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -560,7 +562,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YY5Y5N88U4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -587,7 +589,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YY5Y5N88U4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/Example/OSSSpeechKit/CountryLanguageListTableViewController.swift
+++ b/Example/OSSSpeechKit/CountryLanguageListTableViewController.swift
@@ -105,7 +105,23 @@ extension CountryLanguageListTableViewController {
 }
 
 extension CountryLanguageListTableViewController: OSSSpeechDelegate {
+  
+  func speechSynthesiser(didPerform speechSynthesizerAction: SpeechSynthesizerAction) {
     
+    switch speechSynthesizerAction {
+    case .start(let utterance):
+      print("Utterance Did Start", utterance)
+    case .finish(let utterance):
+      print("Utterance Did Finish", utterance)
+    case .pause(let utterance):
+      print("Utterance Did Start", utterance)
+    case .cancel(let utterance):
+      print("Utterance Did Cancel", utterance)
+    case .willSpeakRange(let range, let utterance):
+      print("Utterance Will Speak" , range, utterance)
+    }
+  }
+  
     func didCompleteTranslation(withText text: String) {
         print("Translation completed: \(text)")
     }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - OSSSpeechKit (0.3.2)
+  - PureLayout (3.1.8)
+
+DEPENDENCIES:
+  - OSSSpeechKit (from `../`)
+  - PureLayout
+
+SPEC REPOS:
+  trunk:
+    - PureLayout
+
+EXTERNAL SOURCES:
+  OSSSpeechKit:
+    :path: "../"
+
+SPEC CHECKSUMS:
+  OSSSpeechKit: d16c1a0b7d25ed23c7d05397ea168037d701e3fc
+  PureLayout: a4afb3d79dd958564ce33d22c89f407280d8e6a8
+
+PODFILE CHECKSUM: 582908e192f56ac5f7e2300684519a46bb3c4a29
+
+COCOAPODS: 1.10.1

--- a/Example/Tests/OSSSpeechTests.swift
+++ b/Example/Tests/OSSSpeechTests.swift
@@ -294,6 +294,8 @@ class OSSSpeechTests: XCTestCase {
 }
 
 extension OSSSpeechTests: OSSSpeechDelegate {
+   func speechSynthesiser(didPerform speechSynthesizerAction: SpeechSynthesizerAction) { }
+  
     func didCompleteTranslation(withText text: String) {
         print("Translation completed with text: \(text)")
     }

--- a/OSSSpeechKit/Classes/OSSSpeech.swift
+++ b/OSSSpeechKit/Classes/OSSSpeech.swift
@@ -25,6 +25,46 @@ import UIKit
 import AVFoundation
 import Speech
 
+//MARK: AVSpeechSynthesis Delegate
+
+extension OSSSpeech: AVSpeechSynthesizerDelegate {
+  
+  public func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
+    delegate?.speechSynthesiser(didPerform: .start(utterance))
+  }
+  
+  public func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+    delegate?.speechSynthesiser(didPerform: .finish(utterance))
+  }
+  
+  public func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer, didPause utterance: AVSpeechUtterance) {
+    delegate?.speechSynthesiser(didPerform: .pause(utterance))
+  }
+  
+  public func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer,
+    didCancel utterance: AVSpeechUtterance) {
+    delegate?.speechSynthesiser(didPerform: .cancel(utterance))
+  }
+  public func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer,
+    willSpeakRangeOfSpeechString characterRange: NSRange, utterance: AVSpeechUtterance) {
+    delegate?.speechSynthesiser(didPerform: .willSpeakRange(characterRange, utterance))
+  }
+}
+
+//A Simplified CallBack For AVSpeechSynthesizerDelegate
+public enum SpeechSynthesizerAction {
+  case start(AVSpeechUtterance)
+  case finish(AVSpeechUtterance)
+  case pause(AVSpeechUtterance)
+  case cancel(AVSpeechUtterance)
+  case willSpeakRange(NSRange, AVSpeechUtterance)
+}
+
 /// The authorization status of the Microphone and recording, imitating the native `SFSpeechRecognizerAuthorizationStatus`
 public enum OSSSpeechKitAuthorizationStatus: Int {
     /// The app's authorization status has not yet been determined.
@@ -157,6 +197,8 @@ public protocol OSSSpeechDelegate: class {
     func didCompleteTranslation(withText text: String)
     /// Error handling function.
     func didFailToProcessRequest(withError error: Error?)
+    //When AVSpeechSynthesizerDelegate Performas An Action
+    func speechSynthesiser(didPerform speechSynthesizerAction: SpeechSynthesizerAction)
 }
 
 /// Speech is the primary interface. To use, set the voice and then call `.speak(string: "your string")`
@@ -221,9 +263,11 @@ public class OSSSpeech: NSObject {
     
     // MARK: - Lifecycle
     
-    private override init() {
-        speechSynthesizer = AVSpeechSynthesizer()
-    }
+  private override init() {
+    super.init()
+    speechSynthesizer = AVSpeechSynthesizer()
+    speechSynthesizer.delegate = self
+  }
     
     private static let sharedInstance: OSSSpeech = {
         return OSSSpeech()


### PR DESCRIPTION
## Notes:
I saw on the develop brach that you had begun to implement a start and finish delegate method for AVSpeechSynthesizer delegate, however I feel it may be more robust to add my changes.

I have added a new delegate callback:

```
//When AVSpeechSynthesizerDelegate Performas An Action
 func speechSynthesiser(didPerform speechSynthesizerAction: SpeechSynthesizerAction)
```

Which passes an enum as a callback:

```
//A Simplified CallBack For AVSpeechSynthesizerDelegate
public enum SpeechSynthesizerAction {
  case start(AVSpeechUtterance)
  case finish(AVSpeechUtterance)
  case pause(AVSpeechUtterance)
  case cancel(AVSpeechUtterance)
  case willSpeakRange(NSRange, AVSpeechUtterance)
}

```

This can then be used like so:

```
extension CountryLanguageListTableViewController: OSSSpeechDelegate {
  
  func speechSynthesiser(didPerform speechSynthesizerAction: SpeechSynthesizerAction) {
    
    switch speechSynthesizerAction {
    case .start(let utterance):
      print("Utterance Did Start", utterance)
    case .finish(let utterance):
      print("Utterance Did Finish", utterance)
    case .pause(let utterance):
      print("Utterance Did Start", utterance)
    case .cancel(let utterance):
      print("Utterance Did Cancel", utterance)
    case .willSpeakRange(let range, let utterance):
      print("Utterance Will Speak" , range, utterance)
    }
  }
}
```
## Key Changes:
add (new delegate method to OSSSpeechDelegate)
add(conformance to AVSpeechSynthesizerDelegate)
add(Debug example to CountryLanguageViewController)
update(pods for Xcode 12.5)