### PR TITLE
Allow injection of the AVSpeechSynthesizer

### DIFF
--- a/Example/Tests/OSSSpeechTests.swift
+++ b/Example/Tests/OSSSpeechTests.swift
@@ -42,6 +42,12 @@ class OSSSpeechTests: XCTestCase {
         speechKit = nil
     }
     
+    func testCanInitWithCustomSynth() {
+        let synth = AVSpeechSynthesizer()
+        let speechKit = OSSSpeech(speechSynthesizer: synth)
+        XCTAssertNotNil(speechKit)
+    }
+    
     func testAudioSessionValid() {
         let exp = expectation(description: "Speech Recogniser Permission")
         var speechAuth = false

--- a/OSSSpeechKit/Classes/OSSSpeech.swift
+++ b/OSSSpeechKit/Classes/OSSSpeech.swift
@@ -224,8 +224,13 @@ public class OSSSpeech: NSObject {
 
     // MARK: - Lifecycle
 
-    private override init() {
-        speechSynthesizer = AVSpeechSynthesizer()
+    
+    /// Allow injection of the AVSpeechSynthesizer so that caller can be AVSpeechSynthesizerDelegate
+    ///     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, willSpeakRangeOfSpeechString characterRange: NSRange, utterance: AVSpeechUtterance) {
+    ///             func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+    /// - Parameter speechSynthesizer
+    public init(speechSynthesizer: AVSpeechSynthesizer = AVSpeechSynthesizer()) {
+        self.speechSynthesizer = speechSynthesizer
     }
 
     private static let sharedInstance: OSSSpeech = {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "OSSSpeechKit",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v13),
         .tvOS(.v13),
 		.macOS(.v11)
     ],


### PR DESCRIPTION
allow external user to be AVSpeechSynthesizerDelegate

func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, willSpeakRangeOfSpeechString characterRange: NSRange, utterance: AVSpeechUtterance)
func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) 
